### PR TITLE
For savegames, write the Harvesting Spot with the Job Driver

### DIFF
--- a/Source/AnimalHarvestingSpot/AnimalHarvestingSpot/JobDriver_AnimalGatheringOnSpot.cs
+++ b/Source/AnimalHarvestingSpot/AnimalHarvestingSpot/JobDriver_AnimalGatheringOnSpot.cs
@@ -35,6 +35,12 @@ namespace AnimalHarvestingSpot
 
         Thing spot = null;
 
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_References.Look(ref spot, "harvesting_spot");
+        }
+
         protected override IEnumerable<Toil> MakeNewToils()
         {
             if (spot != null && !spot.Destroyed)


### PR DESCRIPTION
TL;DR simple fix for tiny problem I ran into when loading a game

`Howard with job Milk (Job_7024901) A=Thing_Cow698767 tried to get CurToil with curToilIndex=4 but only has 2 toils.`
Howard fails to re-load when he's doing a Milking job and has to re-start work.

When Howard started his job, `AnimalHarvestingSpot.TryMakePreToilReservations` found the harvesting spot, then `MakeNewToils` uses the harvesting spot to make a total of 5 toils. The game was saved during toil #4. But when he loads in, there is no `TryMakePreToil` step, so there is no harvesting spot found, so `MakeNewToils` step uses the vanilla 2 toils. 5 is not 2, so error.

So this simply saves the harvesting spot to the save file.

```
Verse.Log:Error(String, Boolean)
Verse.AI.JobDriver:get_CurToil()
Verse.AI.JobDriver:get_HandlingFacing()
Verse.AI.Pawn_JobTracker:get_HandlingFacing()
Verse.Pawn_RotationTracker:UpdateRotation()
Verse.Pawn_RotationTracker:Notify_Spawned()
Verse.Pawn:SpawnSetup_Patch2(Object, Map, Boolean)
Verse.GenSpawn:Spawn_Patch2(Thing, IntVec3, Map, Rot4, WipeMode, Boolean)
Verse.Map:FinalizeLoading_Patch1(Object)
Verse.Game:LoadGame()
Verse.SavedGameLoaderNow:LoadGameFromSaveFileNow(String)
Verse.Root_Play:<Start>m__0()
Verse.LongEventHandler:RunEventFromAnotherThread(Action)
Verse.LongEventHandler:<UpdateCurrentAsynchronousEvent>m__1()
```